### PR TITLE
Hotfix/fix master build

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+
+repository:
+  private: true
+  default_branch: master
+
+teams:
+  - name: dev
+    permission: push
+
+branches:
+  - name: master
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      restrictions: null

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://private-gems.liveramp.net" do
+source "https://public-gems.liveramp.net" do
   gemspec
 
   gem "bundler", ">= 1.15"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source "https://private-gems.liveramp.net" do
+  gemspec
 
-gemspec
-
-gem "bundler", ">= 1.15"
-gem "hurley"
-gem "jruby-openssl", platforms: :jruby
+  gem "bundler", ">= 1.15"
+  gem "hurley"
+  gem "jruby-openssl", platforms: :jruby
+end

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,54 @@
+#!groovy
+@Library("liveramp-base@v1") _
+
+pipeline {
+  options {
+    ansiColor('xterm')
+    disableConcurrentBuilds()
+    buildDiscarder(logRotator(numToKeepStr: '50', daysToKeepStr: '30'))
+  }
+
+  triggers {
+    githubPush()
+    issueCommentTrigger('.*jenkins\\W+(((test|build|run|do)\\W+this)|again|git\\W+r\\W+done|please|make it so).*')
+  }
+
+  agent any
+
+  environment {
+    RUBYGEMS_HOST = 'https://private-gems.liveramp.net'
+  }
+
+  stages {
+    stage('gem:ci') {
+      steps {
+        sh 'bundle install --path=.bundle-gems'
+        sh 'bundle exec rake ci'
+      }
+    }
+
+     stage('gem:release') {
+      when { branch 'master' }
+      steps {
+        withCredentials( bindings:
+          // CredentialsId was found through the credentials page for
+          // jenkins_publisher/****** (library.liveramp.net)
+          [
+            usernamePassword(
+            credentialsId: 'library.liveramp.net--jenkins_publisher',
+            usernameVariable: 'ARTIFACTORY_USERNAME',
+            passwordVariable: 'ARTIFACTORY_PASSWORD'
+            ),
+          ]) {
+            sh 'bundle exec rake ci_release'
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      slackNotification('#dev-ops-builds', 'master')
+    }
+  }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :ci_release => ['generate_rubygems_credentials', 'build', 'release:guard_cl
 
 task :generate_rubygems_credentials do
   require 'base64'
-  GEM_CREDENTIALS = File.join(ENV['HOME'], '/.gem/credentials')
+  GEM_CREDENTIALS = File.join(ENV['HOME'], '.gem/credentials')
   b64_authorization = Base64.encode64("#{ENV.fetch('ARTIFACTORY_USERNAME')}:#{ENV.fetch('ARTIFACTORY_PASSWORD')}")
   open(GEM_CREDENTIALS, 'w') do |f|
     f.puts "---\n:rubygems_api_key: Basic #{b64_authorization}\n"

--- a/Rakefile
+++ b/Rakefile
@@ -1,51 +1,24 @@
-require "rubygems"
-require "rake"
+# -*- ruby -*-
 require "bundler/gem_tasks"
 
-task :release, :tag do |_t, args|
-  tag = args[:tag]
-  raise "You must provide a tag to release." if tag.nil?
-
-  # Verify the tag format "vVERSION"
-  m = tag.match(/v(?<version>\S*)/)
-  raise "Tag #{tag} does not match the expected format." if m.nil?
-
-  version = m[:version]
-  raise "You must provide a version." if version.nil?
-
-  api_token = ENV["RUBYGEMS_API_TOKEN"]
-
-  require "gems"
-  if api_token
-    ::Gems.configure do |config|
-      config.key = api_token
-    end
-  end
-
-  Bundler.with_clean_env do
-    sh "rm -rf pkg"
-    sh "bundle update"
-    sh "bundle exec rake build"
-  end
-
-  path_to_be_pushed = "pkg/#{version}.gem"
-  if File.file? path_to_be_pushed
-    begin
-      ::Gems.push File.new(path_to_be_pushed)
-      puts "Successfully built and pushed signet for version #{version}"
-    rescue StandardError => e
-      puts "Error while releasing signet version #{version}: #{e.message}"
-    end
-  else
-    raise "Cannot build signet for version #{version}"
-  end
-end
-
 task :ci do
-  header "Using Ruby - #{RUBY_VERSION}"
-  sh "bundle exec rubocop"
   sh "bundle exec rspec"
 end
+
+# build, release:guard_clean and release:rubygem_push are the upstream
+# release task minus the git push.
+task :ci_release => ['generate_rubygems_credentials', 'build', 'release:guard_clean', 'release:rubygem_push']
+
+task :generate_rubygems_credentials do
+  require 'base64'
+  GEM_CREDENTIALS = File.join(ENV['HOME'], '/.gem/credentials')
+  b64_authorization = Base64.encode64("#{ENV.fetch('ARTIFACTORY_USERNAME')}:#{ENV.fetch('ARTIFACTORY_PASSWORD')}")
+  open(GEM_CREDENTIALS, 'w') do |f|
+    f.puts "---\n:rubygems_api_key: Basic #{b64_authorization}\n"
+  end
+  File.chmod 0600, GEM_CREDENTIALS
+end
+# end LiveRamp Jenkins CI changes
 
 namespace :kokoro do
   task :load_env_vars do

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -60,6 +60,8 @@ module Signet
       #     Issuer ID when using assertion profile
       #   - <code>:person</code> -
       #     Target user for assertions
+      #   - <code>:additional_claims</code> -
+      #     A hash of additional claims to include in the assertions
       #   - <code>:expiry</code> -
       #     Number of seconds assertions are valid for
       #   - <code>:signing_key</code> -
@@ -104,6 +106,7 @@ module Signet
         @state                = nil
         @username             = nil
         @access_type          = nil
+        @additional_claims    = nil
         update! options
       end
       # rubocop:disable Metrics/AbcSize
@@ -146,6 +149,8 @@ module Signet
       #     Target audience for assertions
       #   - <code>:person</code> -
       #     Target user for assertions
+      #   - <code>:additional_claims</code> -
+      #     A hash of additional claims to include in the assertions
       #   - <code>:expiry</code> -
       #     Number of seconds assertions are valid for
       #   - <code>:signing_key</code> -
@@ -188,6 +193,7 @@ module Signet
         self.password = options[:password] if options.key? :password
         self.issuer = options[:issuer] if options.key? :issuer
         self.person = options[:person] if options.key? :person
+        self.additional_claims = options[:additional_claims] || {}
         self.sub = options[:sub] if options.key? :sub
         self.expiry = options[:expiry] || 60
         self.audience = options[:audience] if options.key? :audience
@@ -581,6 +587,25 @@ module Signet
       alias person= principal=
 
       ##
+      # Returns the additional claims to be encoded in the JWT.
+      # Used only by the assertion grant type.
+      #
+      # @return [Hash] Additional claims
+      def additional_claims
+        @additional_claims ||= {}
+      end
+
+      ##
+      # Sets the additional claims to be encoded in the JWT.
+      # Used only by the assertion grant type.
+      #
+      # @param [Hash] new_additional_claims
+      #   Additional claims
+      def additional_claims= new_additional_claims
+        @additional_claims = new_additional_claims
+      end
+
+      ##
       # The target "sub" when issuing assertions.
       # Used in some Admin SDK APIs.
       #
@@ -895,6 +920,7 @@ module Signet
         assertion["scope"] = scope.join " " unless scope.nil?
         assertion["prn"] = person unless person.nil?
         assertion["sub"] = sub unless sub.nil?
+        assertion.merge! additional_claims
         JWT.encode assertion, signing_key, signing_algorithm
       end
       # rubocop:disable Style/MethodDefParentheses
@@ -920,6 +946,7 @@ module Signet
           "issuer"               => issuer,
           "audience"             => audience,
           "person"               => person,
+          "additional_claims"    => additional_claims,
           "expiry"               => expiry,
           "expires_at"           => expires_at ? expires_at.to_i : nil,
           "signing_key"          => signing_key,

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -19,7 +19,7 @@ unless defined? Signet::VERSION
       MAJOR = 0
       MINOR = 11
       TINY  = 0
-      PRE   = nil
+      PRE   = 'liveramp-001'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."
 

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 3.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9", ">= 0.9.12"
+  gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
 
   gem.post_install_message = Signet::VERSION.warn_on_old_ruby_version
 


### PR DESCRIPTION
`private-gems.liveramp.com` is intentionally not a mirror cache of ruby-gems.org, whereas public-gems is. This changes the Gemfile so that dependent gems are pulled from the mirror cache.
